### PR TITLE
feat: expect NSString token instead NSData

### DIFF
--- a/RNNotifications/RNNRouter.h
+++ b/RNNotifications/RNNRouter.h
@@ -12,7 +12,7 @@
 
 
 @protocol RNNRerouterDelegate <NSObject>
-- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSString *)deviceToken;
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler;
@@ -27,7 +27,7 @@
 
 @property (nonatomic, weak) id <RNNRerouterDelegate> _Nullable delegate;
 
-- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSString *)deviceToken;
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(nullable void (^)(UIBackgroundFetchResult))completionHandler;
 - (void)didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;

--- a/RNNotifications/RNNRouter.m
+++ b/RNNotifications/RNNRouter.m
@@ -39,7 +39,7 @@
     if(self)
     {
         _pendingDelegateCalls = [NSMutableArray new];
-
+    
     }
     return self;
 }
@@ -48,15 +48,15 @@
 - (void)setDelegate:(id<RNNRerouterDelegate,UNUserNotificationCenterDelegate>)delegate
 {
     _delegate = delegate;
-
+    
     while (self.pendingDelegateCalls.count > 0)
     {
         void(^block)(void) = _pendingDelegateCalls.lastObject;
         block();
         [_pendingDelegateCalls removeLastObject];
     }
-
-
+    
+    
 }
 
 
@@ -78,7 +78,7 @@
     void(^callLaterBlock)(void) = ^{
         [self->_delegate userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
     };
-
+    
     if(_delegate)
     {
         callLaterBlock();
@@ -94,7 +94,7 @@
     void(^callLaterBlock)(void) = ^{
         [self->_delegate userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
     };
-
+    
     if(_delegate)
     {
         callLaterBlock();

--- a/RNNotifications/RNNRouter.m
+++ b/RNNotifications/RNNRouter.m
@@ -39,7 +39,7 @@
     if(self)
     {
         _pendingDelegateCalls = [NSMutableArray new];
-        
+
     }
     return self;
 }
@@ -48,15 +48,15 @@
 - (void)setDelegate:(id<RNNRerouterDelegate,UNUserNotificationCenterDelegate>)delegate
 {
     _delegate = delegate;
-    
+
     while (self.pendingDelegateCalls.count > 0)
     {
         void(^block)(void) = _pendingDelegateCalls.lastObject;
         block();
         [_pendingDelegateCalls removeLastObject];
     }
-    
-    
+
+
 }
 
 
@@ -78,7 +78,7 @@
     void(^callLaterBlock)(void) = ^{
         [self->_delegate userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
     };
-    
+
     if(_delegate)
     {
         callLaterBlock();
@@ -94,7 +94,7 @@
     void(^callLaterBlock)(void) = ^{
         [self->_delegate userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
     };
-    
+
     if(_delegate)
     {
         callLaterBlock();
@@ -105,7 +105,7 @@
     }
 }
 
-- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSString *)deviceToken
 {
     if (self.delegate != nil)
     {

--- a/RNNotifications/RNNRouter.m
+++ b/RNNotifications/RNNRouter.m
@@ -39,7 +39,7 @@
     if(self)
     {
         _pendingDelegateCalls = [NSMutableArray new];
-    
+        
     }
     return self;
 }

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -226,7 +226,8 @@ RCT_EXPORT_MODULE()
         
         if (![RNNotificationsBridgeQueue sharedInstance].jsIsReady)
         {
-            [RNNotificationsBridgeQueue sharedInstance].openedLocalNotification = notification.request.content.userInfo;
+            // TODO: schedule emit foreground/background
+            // [RNNotificationsBridgeQueue sharedInstance].openedLocalNotification = notification.request.content.userInfo;
             return;
         }
         
@@ -318,12 +319,15 @@ RCT_EXPORT_MODULE()
     {
         case (int)UIApplicationStateActive:
             [self checkAndSendEvent:RNNotificationReceivedForeground body:userInfo];
+            break;
             
         case (int)UIApplicationStateInactive:
             [self checkAndSendEvent:RNNotificationOpened body:userInfo];
+            break;
             
         default:
             [self checkAndSendEvent:RNNotificationReceivedBackground body:userInfo];
+            break;
     }
 }
 

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -23,6 +23,8 @@ NSString* const RNNotificationActionTriggered = @"RNNotificationActionTriggered"
 NSString* const RNNotificationActionReceived = @"notificationActionReceived";
 //NSString* const RNNotificationActionDismissed = @"RNNotificationActionDismissed";
 
+NSString* const RNNErrorDomain = @"RNNNotificationsError";
+static const int RNNErrorCode = -1;
 
 ////////////////////////////////////////////////////////////////
 #pragma mark conversions
@@ -189,23 +191,34 @@ RCT_EXPORT_MODULE()
 #pragma mark private functions
 ////////////////////////////////////////////////////////////////
 
-+ (void)requestPermissionsWithCategories:(NSMutableSet *)categories
+- (void)requestPermissionsWithCategoriesInternal:(NSMutableSet *)categories
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
         [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge) completionHandler:^(BOOL granted, NSError * _Nullable error){
-            if(!error)
-            {
-                if (granted)
-                {
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:categories];
-                        [[UIApplication sharedApplication] registerForRemoteNotifications];
-                    });
-                }
+            if (error) {
+                [self sendFailedToRegisterEvent:error];
+                return;
             }
+
+            if (!granted) {
+                [self sendFailedToRegisterEvent:[RNNotifications errorWithMessage:@"UserDenied"]];
+                return;
+            }
+
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:categories];
+                [[UIApplication sharedApplication] registerForRemoteNotifications];
+            });
         }];
     });
+}
+
++ (NSError *)errorWithMessage:(NSString *)errorMessage
+{
+    return [NSError errorWithDomain:RNNErrorDomain
+                               code:RNNErrorCode
+                           userInfo:@{ NSLocalizedDescriptionKey: NSLocalizedString(errorMessage, nil) }];
 }
 
 ////////////////////////////////////////////////////////////////
@@ -296,9 +309,15 @@ RCT_EXPORT_MODULE()
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
 {
+    [self sendFailedToRegisterEvent:error];
+}
+
+- (void)sendFailedToRegisterEvent:(NSError *)error
+{
     [self checkAndSendEvent:RNNotificationsRegistrationFailed
                        body:@{@"code": [NSNumber numberWithInteger:error.code], @"domain": error.domain, @"localizedDescription": error.localizedDescription}];
 }
+
 
 //the system calls this method when your app is running in the foreground or background
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
@@ -384,7 +403,7 @@ RCT_EXPORT_METHOD(requestPermissionsWithCategories:(NSArray *)json)
             [categories addObject:[RCTConvert UNNotificationCategory:dic]];
         }
     }
-    [RNNotifications requestPermissionsWithCategories:categories];
+    [self requestPermissionsWithCategoriesInternal:categories];
 }
 
 RCT_EXPORT_METHOD(localNotification:(NSDictionary *)notification withId:(NSString *)notificationId)

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -238,7 +238,6 @@ RCT_EXPORT_MODULE()
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-      
         //        //TODO: check WTF is this
         //        NSMutableDictionary* newUserInfo = notification.request.content.userInfo.mutableCopy;
         //        [newUserInfo removeObjectForKey:@"__id"];
@@ -602,7 +601,7 @@ RCT_EXPORT_METHOD(consumeBackgroundQueue)
 {
     // Mark JS Thread as ready
     [RNNotificationsBridgeQueue sharedInstance].jsIsReady = YES;
-
+    
     // Push actions to JS
     [[RNNotificationsBridgeQueue sharedInstance] consumeActionsQueue:^(NSDictionary* action) {
         [self checkAndSendEvent:RNNotificationActionReceived body:action];

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -402,8 +402,8 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(requestPermissionsWithCategories:(NSDictionary *)json)
 {
-    NSArray *catsArr = [json valueForKey:@"categories"];
-    BOOL requestRemote = [json valueForKey:@"remote"];
+    NSArray *catsArr = [RCTConvert NSArray:json[@"categories"]];
+    BOOL requestRemote = [RCTConvert BOOL:json[@"remote"]];
     NSSet* categories = [RNNotifications interpretNotificationCategories:catsArr];
     [self requestPermissionsWithCategoriesInternal:categories requestRemote:requestRemote];
 }

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -58,7 +58,7 @@ RCT_ENUM_CONVERTER(UNNotificationCategoryOptions, (@{
     UNNotificationAction* action = [UNNotificationAction actionWithIdentifier:details[@"identifier"]
                                                                         title:details[@"title"]
                                                                       options:[RCTConvert UNNotificationActionOptions:details[@"options"]]];
-
+    
     return action;
 }
 @end
@@ -67,7 +67,7 @@ RCT_ENUM_CONVERTER(UNNotificationCategoryOptions, (@{
 + (UNNotificationRequest *)UNNotificationRequest:(id)json withId:(NSString*)notificationId
 {
     NSDictionary<NSString *, id> *details = [self NSDictionary:json];
-
+    
     UNMutableNotificationContent *content = [UNMutableNotificationContent new];
     content.body = [RCTConvert NSString:details[@"alertBody"]];
     content.title = [RCTConvert NSString:details[@"alertTitle"]];
@@ -78,11 +78,11 @@ RCT_ENUM_CONVERTER(UNNotificationCategoryOptions, (@{
     }
     content.userInfo = [RCTConvert NSDictionary:details[@"userInfo"]] ?: @{};
     content.categoryIdentifier = [RCTConvert NSString:details[@"category"]];
-
+    
     NSDate *triggerDate = [RCTConvert NSDate:details[@"fireDate"]];
     UNCalendarNotificationTrigger *trigger = nil;
     NSLog(@"ABOELBISHER : the fire date is %@", triggerDate);
-
+    
     if (triggerDate != nil) {
         NSDateComponents *triggerDateComponents = [[NSCalendar currentCalendar]
                                                    components:NSCalendarUnitYear +
@@ -93,7 +93,7 @@ RCT_ENUM_CONVERTER(UNNotificationCategoryOptions, (@{
         trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:triggerDateComponents
                                                                            repeats:NO];
     }
-
+    
     return [UNNotificationRequest requestWithIdentifier:notificationId
                                                 content:content trigger:trigger];
 }
@@ -105,19 +105,19 @@ RCT_ENUM_CONVERTER(UNNotificationCategoryOptions, (@{
 {
     NSDictionary<NSString *, id> *details = [self NSDictionary:json];
     NSString* identefier = [RCTConvert NSString:details[@"identifier"]];
-
+    
     NSMutableArray* actions = [NSMutableArray new];
     for (NSDictionary* actionJson in [RCTConvert NSArray:details[@"actions"]])
     {
         [actions addObject:[RCTConvert UNNotificationAction:actionJson]];
     }
-
+    
     NSMutableArray* intentIdentifiers = [NSMutableArray new];
     for(NSDictionary* intentJson in [RCTConvert NSArray:details[@"intentIdentifiers"]])
     {
         [intentIdentifiers addObject:[RCTConvert NSString:intentJson]];
     }
-
+    
     UNNotificationCategory* cat =  [UNNotificationCategory categoryWithIdentifier:identefier
                                                                           actions:actions
                                                                 intentIdentifiers:intentIdentifiers
@@ -130,22 +130,22 @@ static NSDictionary *RCTFormatUNNotification(UNNotification *notification)
 {
     NSMutableDictionary *formattedNotification = [NSMutableDictionary dictionary];
     UNNotificationContent *content = notification.request.content;
-
+    
     formattedNotification[@"identifier"] = notification.request.identifier;
-
+    
     if (notification.date) {
         NSDateFormatter *formatter = [NSDateFormatter new];
         [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"];
         NSString *dateString = [formatter stringFromDate:notification.date];
         formattedNotification[@"fireDate"] = dateString;
     }
-
+    
     formattedNotification[@"alertTitle"] = RCTNullIfNil(content.title);
     formattedNotification[@"alertBody"] = RCTNullIfNil(content.body);
     formattedNotification[@"category"] = RCTNullIfNil(content.categoryIdentifier);
     formattedNotification[@"thread-id"] = RCTNullIfNil(content.threadIdentifier);
     formattedNotification[@"userInfo"] = RCTNullIfNil(RCTJSONClean(content.userInfo));
-
+    
     return formattedNotification;
 }
 
@@ -188,7 +188,7 @@ RCT_EXPORT_MODULE()
     [RNNotificationsBridgeQueue sharedInstance].openedRemoteNotification = [bridge.launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
     //    UILocalNotification *localNotification = [bridge.launchOptions objectForKey:UIApplicationLaunchOptionsLocalNotificationKey];
     //    [RNNotificationsBridgeQueue sharedInstance].openedLocalNotification = localNotification ? localNotification.userInfo : nil;
-
+    
 }
 
 ////////////////////////////////////////////////////////////////
@@ -238,20 +238,20 @@ RCT_EXPORT_MODULE()
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-
+      
         //        //TODO: check WTF is this
         //        NSMutableDictionary* newUserInfo = notification.request.content.userInfo.mutableCopy;
         //        [newUserInfo removeObjectForKey:@"__id"];
         //        notification.request.content.userInfo = newUserInfo;
         //        ////
-
+        
         if (![RNNotificationsBridgeQueue sharedInstance].jsIsReady)
         {
             // TODO: schedule emit foreground/background
             // [RNNotificationsBridgeQueue sharedInstance].openedLocalNotification = notification.request.content.userInfo;
             return;
         }
-
+        
         NSLog(@"ABOELBISHER : willPresentNotification");
         UIApplicationState state = [UIApplication sharedApplication].applicationState;
         [self handleReceiveNotification:state userInfo:notification.request.content.userInfo];
@@ -285,28 +285,28 @@ RCT_EXPORT_MODULE()
 
     NSString* completionKey = [NSString stringWithFormat:@"%@.%@", identifier, [NSString stringWithFormat:@"%ld", (long)[[NSDate date] timeIntervalSince1970]]];
     NSMutableDictionary* info = [[NSMutableDictionary alloc] initWithDictionary:@{ @"identifier": identifier, @"completionKey": completionKey }];
-
+    
     // add text
     NSString* text = ((UNTextInputNotificationResponse*)response).userText;//[response objectForKey:UIUserNotificationActionResponseTypedTextKey];
     if (text != NULL) {
         info[@"text"] = text;
     }
-
+    
     // add notification custom data
     if (userInfo != NULL) {
         info[@"notification"] = userInfo;
     }
-
+    
     // Emit event to the queue (in order to store the completion handler). if JS thread is ready, post it also to the notification center (to the bridge).
     [[RNNotificationsBridgeQueue sharedInstance] postAction:info withCompletionKey:completionKey andCompletionHandler:completionHandler];
-
+    
     if ([RNNotificationsBridgeQueue sharedInstance].jsIsReady == YES) {
         [self checkAndSendEvent:RNNotificationActionTriggered body:info];
         completionHandler();
     } else {
         [RNNotificationsBridgeQueue sharedInstance].openedLocalNotification = info;
     }
-
+    
 }
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSString *)deviceToken
@@ -346,11 +346,11 @@ RCT_EXPORT_MODULE()
         case (int)UIApplicationStateActive:
             [self checkAndSendEvent:RNNotificationReceivedForeground body:userInfo];
             break;
-
+            
         case (int)UIApplicationStateInactive:
             [self checkAndSendEvent:RNNotificationOpened body:userInfo];
             break;
-
+            
         default:
             [self checkAndSendEvent:RNNotificationReceivedBackground body:userInfo];
             break;
@@ -368,13 +368,13 @@ RCT_EXPORT_MODULE()
 
 - (NSArray<NSString *> *)supportedEvents
 {
-
+    
     return @[ RNNotificationsRegistered,
               RNNotificationsRegistrationFailed,
               RNNotificationReceivedForeground,
               RNNotificationReceivedBackground,
               RNNotificationOpened];
-
+    
 }
 
 -(void) checkAndSendEvent:(NSString*)name body:(id)body
@@ -451,21 +451,21 @@ RCT_EXPORT_METHOD(setBadgesCount:(int)count)
     NSDictionary* alert = [managedAps objectForKey:@"alert"];
     NSString* action = [managedAps objectForKey:@"action"];
     NSString* notificationId = [managedAps objectForKey:@"notificationId"];
-
+    
     if (action) {
         // create or delete notification
         if ([action isEqualToString: RNNotificationCreateAction]
             && notificationId
             && alert) {
             [self dispatchLocalNotificationFromNotification:notification];
-
+            
         } else if ([action isEqualToString: RNNotificationClearAction] && notificationId) {
             [self clearNotificationFromNotificationsCenter:notificationId];
         }
     }
-
+    
     [self checkAndSendEvent:RNNotificationReceivedBackground body:notification];
-
+    
 }
 
 + (void)didNotificationOpen:(NSDictionary *)notification
@@ -499,11 +499,11 @@ RCT_EXPORT_METHOD(setBadgesCount:(int)count)
     NSDictionary* alert = [managedAps objectForKey:@"alert"];
     NSString* action = [managedAps objectForKey:@"action"];
     NSString* notificationId = [managedAps objectForKey:@"notificationId"];
-
+    
     if ([action isEqualToString: RNNotificationCreateAction]
         && notificationId
         && alert) {
-
+        
         // trigger new client push notification
         UILocalNotification* note = [UILocalNotification new];
         note.alertTitle = [alert objectForKey:@"title"];
@@ -511,15 +511,15 @@ RCT_EXPORT_METHOD(setBadgesCount:(int)count)
         note.userInfo = notification;
         note.soundName = [managedAps objectForKey:@"sound"];
         note.category = [managedAps objectForKey:@"category"];
-
+        
         [[UIApplication sharedApplication] presentLocalNotificationNow:note];
-
+        
         // Serialize it and store so we can delete it later
         NSData* data = [NSKeyedArchiver archivedDataWithRootObject:note];
         NSString* notificationKey = [self buildNotificationKeyfromNotification:notificationId];
         [[NSUserDefaults standardUserDefaults] setObject:data forKey:notificationKey];
         [[NSUserDefaults standardUserDefaults] synchronize];
-
+        
         NSLog(@"Local notification was triggered: %@", notificationKey);
     }
 }
@@ -530,13 +530,13 @@ RCT_EXPORT_METHOD(setBadgesCount:(int)count)
     NSData* data = [[NSUserDefaults standardUserDefaults] objectForKey:notificationKey];
     if (data) {
         UILocalNotification* notification = [NSKeyedUnarchiver unarchiveObjectWithData: data];
-
+        
         // delete the notification
         [[UIApplication sharedApplication] cancelLocalNotification:notification];
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:notificationKey];
-
+        
         NSLog(@"Local notification removed: %@", notificationKey);
-
+        
         return;
     }
 }
@@ -554,7 +554,7 @@ RCT_EXPORT_METHOD(setBadgesCount:(int)count)
     for (NSUInteger i = 0; i < deviceTokenLength; i++) {
         [result appendFormat:@"%02x", bytes[i]];
     }
-
+    
     return [result copy];
 }
 
@@ -582,7 +582,7 @@ RCT_EXPORT_METHOD(registerPushKit)
     dispatch_async(dispatch_get_main_queue(), ^{
         // Create a push registry object
         PKPushRegistry* pushKitRegistry = [[PKPushRegistry alloc] initWithQueue:dispatch_get_main_queue()];
-
+        
         // Set the registry delegate to app delegate
         pushKitRegistry.delegate = [[UIApplication sharedApplication] delegate];
         pushKitRegistry.desiredPushTypes = [NSSet setWithObject:PKPushTypeVoIP];
@@ -607,19 +607,19 @@ RCT_EXPORT_METHOD(consumeBackgroundQueue)
     [[RNNotificationsBridgeQueue sharedInstance] consumeActionsQueue:^(NSDictionary* action) {
         [self checkAndSendEvent:RNNotificationActionReceived body:action];
     }];
-
+    
     // Push background notifications to JS
     [[RNNotificationsBridgeQueue sharedInstance] consumeNotificationsQueue:^(NSDictionary* notification) {
         [self didReceiveNotificationOnBackgroundState:notification];
     }];
-
+    
     // Push opened local notifications
     NSDictionary* openedLocalNotification = [RNNotificationsBridgeQueue sharedInstance].openedLocalNotification;
     if (openedLocalNotification) {
         [RNNotificationsBridgeQueue sharedInstance].openedLocalNotification = nil;
         [self checkAndSendEvent:RNNotificationOpened body:openedLocalNotification];
     }
-
+    
     // Push opened remote notifications
     NSDictionary* openedRemoteNotification = [RNNotificationsBridgeQueue sharedInstance].openedRemoteNotification;
     if (openedRemoteNotification) {
@@ -637,7 +637,7 @@ RCT_EXPORT_METHOD(cancelAllLocalNotifications)
 RCT_EXPORT_METHOD(isRegisteredForRemoteNotifications:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 {
     BOOL ans;
-
+    
     if (TARGET_IPHONE_SIMULATOR) {
         ans = [[[UIApplication sharedApplication] currentUserNotificationSettings] types] != 0;
     }
@@ -681,7 +681,7 @@ RCT_EXPORT_METHOD(getDeliveredNotifications:(RCTResponseSenderBlock)callback)
         UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
         [center getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
             NSMutableArray<NSDictionary *> *formattedNotifications = [NSMutableArray new];
-
+            
             for (UNNotification *notification in notifications) {
                 [formattedNotifications addObject:RCTFormatUNNotification(notification)];
             }

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -174,7 +174,11 @@ RCT_EXPORT_MODULE()
     return self;
 }
 
-
++ (BOOL)requiresMainQueueSetup
+{
+    // TODO: figure out if we can return NO
+    return YES;
+}
 
 - (void)setBridge:(RCTBridge *)bridge
 {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,7 +40,7 @@ And the following methods to support registration and receiving notifications:
   [[RNNRouter sharedInstance] application:application didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
-- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSString *)deviceToken
 {
   [[RNNRouter sharedInstance] application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
@@ -77,7 +77,7 @@ Declare the library as a dependency in your **app-project's** `build.gradle`:
 ```gradle
 dependencies {
 	// ...
-	
+
 	compile project(':reactnativenotifications')
 }
 ```

--- a/example/ios/NotificationsExampleApp/AppDelegate.m
+++ b/example/ios/NotificationsExampleApp/AppDelegate.m
@@ -20,22 +20,22 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   NSURL *jsCodeLocation;
-  
+
   jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
-  
+
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"NotificationsExampleApp"
                                                initialProperties:nil
                                                    launchOptions:launchOptions];
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
-  
+
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   [UNUserNotificationCenter currentNotificationCenter].delegate = self;
-  
+
   return YES;
 }
 
@@ -55,7 +55,7 @@
   [[RNNRouter sharedInstance] application:application didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
-- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSString *)deviceToken
 {
   [[RNNRouter sharedInstance] application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }

--- a/example/ios/NotificationsExampleApp/AppDelegate.m
+++ b/example/ios/NotificationsExampleApp/AppDelegate.m
@@ -20,22 +20,22 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   NSURL *jsCodeLocation;
-
+  
   jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
-
+  
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"NotificationsExampleApp"
                                                initialProperties:nil
                                                    launchOptions:launchOptions];
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
-
+  
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   [UNUserNotificationCenter currentNotificationCenter].delegate = self;
-
+  
   return YES;
 }
 

--- a/index.ios.js
+++ b/index.ios.js
@@ -126,7 +126,7 @@ export default class NotificationsIOS {
       opts = { categories: opts }
     }
 
-    const { categories, remote } = opts
+    const { categories, remote=true } = opts
     let notificationCategories = [];
 
     if (categories) {

--- a/index.ios.js
+++ b/index.ios.js
@@ -120,7 +120,13 @@ export default class NotificationsIOS {
   /**
    * Sets the notification categories
    */
-  static requestPermissions(categories: Array<NotificationCategory>) {
+  static requestPermissions(opts) {
+    // backwards compat
+    if (Array.isArray(opts)) {
+      opts = { categories: opts }
+    }
+
+    const { categories, remote } = opts
     let notificationCategories = [];
 
     if (categories) {
@@ -139,7 +145,10 @@ export default class NotificationsIOS {
       });
     }
 
-    RNNotifications.requestPermissionsWithCategories(notificationCategories);
+    RNNotifications.requestPermissionsWithCategories({
+      categories: notificationCategories,
+      remote
+    });
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-notifications",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Advanced Push Notifications (Silent, interactive notifications) for iOS & Android",
   "author": "Lidan Hifi <lidan.hifi@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-notifications",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Advanced Push Notifications (Silent, interactive notifications) for iOS & Android",
   "author": "Lidan Hifi <lidan.hifi@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-notifications",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Advanced Push Notifications (Silent, interactive notifications) for iOS & Android",
   "author": "Lidan Hifi <lidan.hifi@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-notifications",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Advanced Push Notifications (Silent, interactive notifications) for iOS & Android",
   "author": "Lidan Hifi <lidan.hifi@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-notifications",
+  "name": "@exodus/react-native-notifications",
   "version": "1.3.0",
   "description": "Advanced Push Notifications (Silent, interactive notifications) for iOS & Android",
   "author": "Lidan Hifi <lidan.hifi@gmail.com>",
@@ -50,11 +50,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/wix/react-native-notifications.git"
+    "url": "https://github.com/ExodusMovement/react-native-notifications.git"
   },
-  "homepage": "https://github.com/wix/react-native-notifications",
+  "homepage": "https://github.com/ExodusMovement/react-native-notifications",
   "bugs": {
-    "url": "https://github.com/wix/react-native-notifications/issues"
+    "url": "https://github.com/ExodusMovement/react-native-notifications/issues"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-notifications",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Advanced Push Notifications (Silent, interactive notifications) for iOS & Android",
   "author": "Lidan Hifi <lidan.hifi@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Expect token of type `NSString` instead of `NSData`. This is needed to add compatibility for FCM tokens which are strings (see [here](https://firebase.google.com/docs/cloud-messaging/ios/client#fetching-the-current-registration-token)). If for some reason we want to have support for both types of tokens we can move this [logic](https://github.com/ExodusMovement/react-native-notifications/blob/c11cd6b0765ed03b65a970a56fd972d285bf0c52/RNNotifications/RNNotifications.m#L549) to our app. I tried transforming `NSString` to `NSData` on our end but couldn't. Tried all encodings but none ended up producing the correct output. 
